### PR TITLE
Add SerializationUtil with optional GZIP compression

### DIFF
--- a/src/main/java/com/example/SerializationUtil.java
+++ b/src/main/java/com/example/SerializationUtil.java
@@ -19,24 +19,54 @@ public class SerializationUtil {
     }
 
     public static void serialize(Object obj, Path path, boolean compress) throws IOException {
-        try (OutputStream file = Files.newOutputStream(path);
-             OutputStream out = compress ? new GZIPOutputStream(file) : file;
-             ObjectOutputStream oos = new ObjectOutputStream(out)) {
-            oos.writeObject(obj);
+        try (OutputStream file = Files.newOutputStream(path)) {
+            if (compress) {
+                try (GZIPOutputStream gzip = new GZIPOutputStream(file);
+                     ObjectOutputStream oos = new ObjectOutputStream(gzip)) {
+                    oos.writeObject(obj);
+                }
+            } else {
+                try (ObjectOutputStream oos = new ObjectOutputStream(file)) {
+                    oos.writeObject(obj);
+                }
+            }
         }
     }
 
+    /**
+     * Deserializes an object from the given path.
+     *
+     * <p><strong>Security warning:</strong> Java native deserialization is a known
+     * remote-code-execution vector. Only deserialize data from fully trusted sources.
+     * Consider using {@link ObjectInputStream#setObjectInputFilter} or switching to
+     * a safer format (JSON, Protobuf) for untrusted data.
+     *
+     * <p>The returned type is unchecked — a type mismatch throws {@link ClassCastException}
+     * at the call site, not inside this method.
+     */
     @SuppressWarnings("unchecked")
     public static <T> T deserialize(Path path) throws IOException, ClassNotFoundException {
         return deserialize(path, false);
     }
 
+    /**
+     * Deserializes an object from the given path, optionally decompressing with GZIP.
+     *
+     * @see #deserialize(Path)
+     */
     @SuppressWarnings("unchecked")
     public static <T> T deserialize(Path path, boolean compress) throws IOException, ClassNotFoundException {
-        try (InputStream file = Files.newInputStream(path);
-             InputStream in = compress ? new GZIPInputStream(file) : file;
-             ObjectInputStream ois = new ObjectInputStream(in)) {
-            return (T) ois.readObject();
+        try (InputStream file = Files.newInputStream(path)) {
+            if (compress) {
+                try (GZIPInputStream gzip = new GZIPInputStream(file);
+                     ObjectInputStream ois = new ObjectInputStream(gzip)) {
+                    return (T) ois.readObject();
+                }
+            } else {
+                try (ObjectInputStream ois = new ObjectInputStream(file)) {
+                    return (T) ois.readObject();
+                }
+            }
         }
     }
 }

--- a/src/test/java/com/example/SerializationUtilTest.java
+++ b/src/test/java/com/example/SerializationUtilTest.java
@@ -54,10 +54,17 @@ class SerializationUtilTest {
     }
 
     @Test
-    void deserializeWrongCompressionFlagThrows() throws Exception {
+    void deserializePlainAsCompressedThrows() throws Exception {
         Path file = tempDir.resolve("plain.ser");
         SerializationUtil.serialize("data", file, false);
         assertThrows(IOException.class, () -> SerializationUtil.deserialize(file, true));
+    }
+
+    @Test
+    void deserializeCompressedAsPlainThrows() throws Exception {
+        Path file = tempDir.resolve("compressed.ser.gz");
+        SerializationUtil.serialize("data", file, true);
+        assertThrows(IOException.class, () -> SerializationUtil.deserialize(file, false));
     }
 
     @Test
@@ -66,5 +73,21 @@ class SerializationUtilTest {
         Object notSerializable = new Object() {};
         assertThrows(NotSerializableException.class,
                 () -> SerializationUtil.serialize(notSerializable, file));
+    }
+
+    @Test
+    void deserializeNonExistentFileThrows() {
+        Path file = tempDir.resolve("missing.ser");
+        assertThrows(IOException.class, () -> SerializationUtil.deserialize(file));
+    }
+
+    @Test
+    void wrongTypeThrowsClassCastException() throws Exception {
+        Path file = tempDir.resolve("int.ser");
+        SerializationUtil.serialize(42, file);
+        assertThrows(ClassCastException.class, () -> {
+            String result = SerializationUtil.deserialize(file);
+            result.length(); // trigger cast
+        });
     }
 }


### PR DESCRIPTION
## Summary
- Nová util třída `SerializationUtil` pro serializaci/deserializaci Java objektů na disk
- Volitelná GZIP komprese přes boolean parametr `compress`
- API: `serialize(Object, Path)`, `serialize(Object, Path, boolean)`, `deserialize(Path)`, `deserialize(Path, boolean)`

## Test plan
- [x] Serializace a deserializace Stringu
- [x] Serializace a deserializace s kompresí
- [x] Komprimovaný soubor je menší než nekomprimovaný
- [x] Serializace komplexního objektu (List)
- [x] Čtení s nesprávným compression flag vyhodí IOException
- [x] Serializace neserializovatelného objektu vyhodí NotSerializableException
- [x] `gradle test` prošel (16 testů)

🤖 Generated with [Claude Code](https://claude.com/claude-code)