### PR TITLE
Add multi-codec compression with automatic best-codec selection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.tukaani:xz:1.9'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/example/SerializationUtil.java
+++ b/src/main/java/com/example/SerializationUtil.java
@@ -1,7 +1,12 @@
 package com.example;
 
+import org.tukaani.xz.LZMA2Options;
+import org.tukaani.xz.XZInputStream;
+import org.tukaani.xz.XZOutputStream;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -14,37 +19,69 @@ import java.util.zip.GZIPOutputStream;
 
 public class SerializationUtil {
 
-    private static final byte MAGIC_PLAIN = 0x00;
-    private static final byte MAGIC_GZIP  = 0x01;
+    /** First byte of every serialized file — identifies the compression codec used. */
+    private static final int MAGIC_PLAIN = 0x00;
+    private static final int MAGIC_GZIP  = 0x01;
+    private static final int MAGIC_XZ    = 0x02;
+
+    /** Supported compression codecs. */
+    public enum Compression {
+        NONE, GZIP, XZ
+    }
 
     private SerializationUtil() {}
 
+    /** Serializes {@code obj} to {@code path} without compression. */
     public static void serialize(Object obj, Path path) throws IOException {
-        serialize(obj, path, false);
+        serialize(obj, path, Compression.NONE);
     }
 
+    /**
+     * Serializes {@code obj} to {@code path}.
+     *
+     * <p>When {@code compress} is {@code true}, all available compression codecs
+     * (GZIP, XZ) are tried in memory and the one producing the smallest output is used.
+     * The chosen codec is recorded in the magic byte so that {@link #deserialize(Path)}
+     * can detect it automatically.
+     *
+     * <p>When {@code compress} is {@code false}, no compression is applied.
+     */
     public static void serialize(Object obj, Path path, boolean compress) throws IOException {
-        try (OutputStream file = Files.newOutputStream(path);
-             BufferedOutputStream buf = new BufferedOutputStream(file)) {
-            buf.write(compress ? MAGIC_GZIP : MAGIC_PLAIN);
-            if (compress) {
-                try (GZIPOutputStream gzip = new GZIPOutputStream(buf);
-                     ObjectOutputStream oos = new ObjectOutputStream(gzip)) {
-                    oos.writeObject(obj);
-                }
-            } else {
-                try (ObjectOutputStream oos = new ObjectOutputStream(buf)) {
-                    oos.writeObject(obj);
-                }
-            }
+        if (!compress) {
+            serialize(obj, path, Compression.NONE);
+            return;
+        }
+        byte[] raw     = toBytes(obj);
+        byte[] gzipped = compress(raw, Compression.GZIP);
+        byte[] xzed    = compress(raw, Compression.XZ);
+        if (gzipped.length <= xzed.length) {
+            writeToFile(path, MAGIC_GZIP, gzipped);
+        } else {
+            writeToFile(path, MAGIC_XZ, xzed);
+        }
+    }
+
+    /**
+     * Serializes {@code obj} to {@code path} using the specified compression {@code codec}.
+     * The codec is recorded in the magic byte so that {@link #deserialize(Path)}
+     * can detect it automatically.
+     */
+    public static void serialize(Object obj, Path path, Compression codec) throws IOException {
+        byte[] raw = toBytes(obj);
+        if (codec == Compression.NONE) {
+            writeToFile(path, MAGIC_PLAIN, raw);
+        } else {
+            byte[] compressed = compress(raw, codec);
+            int magic = (codec == Compression.GZIP) ? MAGIC_GZIP : MAGIC_XZ;
+            writeToFile(path, magic, compressed);
         }
     }
 
     /**
      * Deserializes an object from the given path.
      *
-     * <p>The compression format is detected automatically from the first byte written
-     * by {@link #serialize(Object, Path, boolean)}.
+     * <p>The compression format is detected automatically from the magic byte written
+     * by any of the {@code serialize} overloads (0x00 = none, 0x01 = GZIP, 0x02 = XZ).
      *
      * <p><strong>Security warning:</strong> Java native deserialization is a known
      * remote-code-execution vector. Only deserialize data from fully trusted sources.
@@ -62,18 +99,57 @@ public class SerializationUtil {
             if (magic == -1) {
                 throw new IOException("File is empty: " + path);
             }
-            if (magic == MAGIC_GZIP) {
+            if (magic == MAGIC_PLAIN) {
+                try (ObjectInputStream ois = new ObjectInputStream(buf)) {
+                    return (T) ois.readObject();
+                }
+            } else if (magic == MAGIC_GZIP) {
                 try (GZIPInputStream gzip = new GZIPInputStream(buf);
                      ObjectInputStream ois = new ObjectInputStream(gzip)) {
                     return (T) ois.readObject();
                 }
-            } else if (magic == MAGIC_PLAIN) {
-                try (ObjectInputStream ois = new ObjectInputStream(buf)) {
+            } else if (magic == MAGIC_XZ) {
+                try (XZInputStream xz = new XZInputStream(buf);
+                     ObjectInputStream ois = new ObjectInputStream(xz)) {
                     return (T) ois.readObject();
                 }
             } else {
                 throw new IOException("Unknown format byte 0x" + Integer.toHexString(magic) + " in: " + path);
             }
+        }
+    }
+
+    private static byte[] toBytes(Object obj) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(obj);
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] compress(byte[] data, Compression codec) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        switch (codec) {
+            case GZIP -> {
+                try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+                    gzip.write(data);
+                }
+            }
+            case XZ -> {
+                try (XZOutputStream xz = new XZOutputStream(baos, new LZMA2Options())) {
+                    xz.write(data);
+                }
+            }
+            default -> throw new IllegalArgumentException("Cannot compress with codec: " + codec);
+        }
+        return baos.toByteArray();
+    }
+
+    private static void writeToFile(Path path, int magic, byte[] data) throws IOException {
+        try (OutputStream file = Files.newOutputStream(path);
+             BufferedOutputStream buf = new BufferedOutputStream(file)) {
+            buf.write(magic);
+            buf.write(data);
         }
     }
 }

--- a/src/test/java/com/example/SerializationUtilTest.java
+++ b/src/test/java/com/example/SerializationUtilTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 class SerializationUtilTest {
 
@@ -102,5 +103,75 @@ class SerializationUtilTest {
             String result = SerializationUtil.deserialize(file);
             result.length(); // trigger cast
         });
+    }
+
+    @Test
+    void serializeAndDeserializeWithExplicitGzipCodec() throws Exception {
+        Path file = tempDir.resolve("test.ser.gz");
+        SerializationUtil.serialize("hello world", file, SerializationUtil.Compression.GZIP);
+        String result = SerializationUtil.deserialize(file);
+        assertEquals("hello world", result);
+    }
+
+    @Test
+    void serializeAndDeserializeWithExplicitXzCodec() throws Exception {
+        Path file = tempDir.resolve("test.ser.xz");
+        SerializationUtil.serialize("hello world", file, SerializationUtil.Compression.XZ);
+        String result = SerializationUtil.deserialize(file);
+        assertEquals("hello world", result);
+    }
+
+    @Test
+    void allCodecsRoundTripComplexObject() throws Exception {
+        java.util.List<Integer> original = java.util.List.of(1, 2, 3, 4, 5);
+        for (SerializationUtil.Compression codec : SerializationUtil.Compression.values()) {
+            Path file = tempDir.resolve("list-" + codec + ".ser");
+            SerializationUtil.serialize(original, file, codec);
+            java.util.List<Integer> result = SerializationUtil.deserialize(file);
+            assertEquals(original, result, "Round-trip failed for codec: " + codec);
+        }
+    }
+
+    @Test
+    void autoCompressionWritesGzipOrXzMagicByte() throws Exception {
+        byte[] data = new byte[100_000];
+        Path file = tempDir.resolve("auto.ser");
+        SerializationUtil.serialize(data, file, true);
+
+        byte magic = Files.readAllBytes(file)[0];
+        assertTrue(magic == 0x01 || magic == 0x02,
+                "Expected GZIP (0x01) or XZ (0x02) magic byte, got: 0x" + Integer.toHexString(magic & 0xFF));
+    }
+
+    @Test
+    void autoCompressionPicksSmallestCodec() throws Exception {
+        // 100K zeros are highly compressible — auto should pick whichever codec wins
+        byte[] data = new byte[100_000];
+        Path auto  = tempDir.resolve("auto.ser");
+        Path gzip  = tempDir.resolve("gzip.ser");
+        Path xz    = tempDir.resolve("xz.ser");
+
+        SerializationUtil.serialize(data, auto,  true);
+        SerializationUtil.serialize(data, gzip,  SerializationUtil.Compression.GZIP);
+        SerializationUtil.serialize(data, xz,    SerializationUtil.Compression.XZ);
+
+        long autoSize = Files.size(auto);
+        long minSize  = Math.min(Files.size(gzip), Files.size(xz));
+        assertEquals(minSize, autoSize, "Auto-selected file should match the smallest individual codec");
+
+        // Must also deserialize correctly
+        assertArrayEquals(data, (byte[]) SerializationUtil.deserialize(auto));
+    }
+
+    @Test
+    void xzCompressedFileIsSmallerForLargeData() throws Exception {
+        byte[] data = new byte[100_000];
+        Path plain = tempDir.resolve("plain.ser");
+        Path xz    = tempDir.resolve("compressed.ser.xz");
+
+        SerializationUtil.serialize(data, plain);
+        SerializationUtil.serialize(data, xz, SerializationUtil.Compression.XZ);
+
+        assertTrue(Files.size(xz) < Files.size(plain));
     }
 }


### PR DESCRIPTION
## Summary

- Přidán XZ (LZMA2) kodek přes `org.tukaani:xz:1.9` — žádná jiná závislost není potřeba
- Nový `Compression` enum (`NONE`, `GZIP`, `XZ`) pro explicitní volbu kodeku přes nový overload `serialize(obj, path, Compression)`
- `serialize(obj, path, true)` nyní zkusí GZIP i XZ v paměti a zapíše ten menší výsledek; použitý kodek je zakódován do magic byte (`0x00` = plain, `0x01` = GZIP, `0x02` = XZ)
- `deserialize()` rozšířen o XZ větev — čte magic byte a automaticky volí správný dekompresor
- Všechny stávající testy zůstávají zelené, přidáno 6 nových testů (celkem 16)

## Test plan

- [x] `serializeAndDeserializeWithExplicitGzipCodec` — round-trip přes GZIP enum
- [x] `serializeAndDeserializeWithExplicitXzCodec` — round-trip přes XZ enum
- [x] `allCodecsRoundTripComplexObject` — iteruje přes všechny hodnoty enumu
- [x] `autoCompressionWritesGzipOrXzMagicByte` — ověří magic byte při auto-výběru
- [x] `autoCompressionPicksSmallestCodec` — ověří že auto-výběr = nejmenší z GZIP/XZ
- [x] `xzCompressedFileIsSmallerForLargeData` — XZ < nekomprimované pro velká data

🤖 Generated with [Claude Code](https://claude.com/claude-code)