### PR TITLE
Add BZip2 codec and CountingOutputStream for memory-efficient auto-selection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 
 dependencies {
     implementation 'org.tukaani:xz:1.9'
+    implementation 'org.apache.commons:commons-compress:1.26.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/test/java/com/example/SerializationUtilTest.java
+++ b/src/test/java/com/example/SerializationUtilTest.java
@@ -133,30 +133,53 @@ class SerializationUtilTest {
     }
 
     @Test
-    void autoCompressionWritesGzipOrXzMagicByte() throws Exception {
+    void serializeAndDeserializeWithExplicitBzip2Codec() throws Exception {
+        Path file = tempDir.resolve("test.ser.bz2");
+        SerializationUtil.serialize("hello world", file, SerializationUtil.Compression.BZIP2);
+        String result = SerializationUtil.deserialize(file);
+        assertEquals("hello world", result);
+    }
+
+    @Test
+    void bzip2CompressedFileIsSmallerForLargeData() throws Exception {
+        byte[] data = new byte[100_000];
+        Path plain = tempDir.resolve("plain.ser");
+        Path bzip2 = tempDir.resolve("compressed.ser.bz2");
+
+        SerializationUtil.serialize(data, plain);
+        SerializationUtil.serialize(data, bzip2, SerializationUtil.Compression.BZIP2);
+
+        assertTrue(Files.size(bzip2) < Files.size(plain));
+    }
+
+    @Test
+    void autoCompressionWritesCompressedMagicByte() throws Exception {
         byte[] data = new byte[100_000];
         Path file = tempDir.resolve("auto.ser");
         SerializationUtil.serialize(data, file, true);
 
         byte magic = Files.readAllBytes(file)[0];
-        assertTrue(magic == 0x01 || magic == 0x02,
-                "Expected GZIP (0x01) or XZ (0x02) magic byte, got: 0x" + Integer.toHexString(magic & 0xFF));
+        assertTrue(magic == 0x01 || magic == 0x02 || magic == 0x03,
+                "Expected GZIP (0x01), XZ (0x02), or BZip2 (0x03) magic byte, got: 0x"
+                        + Integer.toHexString(magic & 0xFF));
     }
 
     @Test
     void autoCompressionPicksSmallestCodec() throws Exception {
-        // 100K zeros are highly compressible — auto should pick whichever codec wins
+        // 100K zeros are highly compressible — auto should match the smallest individual codec
         byte[] data = new byte[100_000];
         Path auto  = tempDir.resolve("auto.ser");
         Path gzip  = tempDir.resolve("gzip.ser");
         Path xz    = tempDir.resolve("xz.ser");
+        Path bzip2 = tempDir.resolve("bzip2.ser");
 
         SerializationUtil.serialize(data, auto,  true);
         SerializationUtil.serialize(data, gzip,  SerializationUtil.Compression.GZIP);
         SerializationUtil.serialize(data, xz,    SerializationUtil.Compression.XZ);
+        SerializationUtil.serialize(data, bzip2, SerializationUtil.Compression.BZIP2);
 
         long autoSize = Files.size(auto);
-        long minSize  = Math.min(Files.size(gzip), Files.size(xz));
+        long minSize  = Math.min(Files.size(gzip), Math.min(Files.size(xz), Files.size(bzip2)));
         assertEquals(minSize, autoSize, "Auto-selected file should match the smallest individual codec");
 
         // Must also deserialize correctly


### PR DESCRIPTION
## Summary

- Přidán `Compression.BZIP2` (magic byte `0x03`) přes `org.apache.commons:commons-compress:1.26.2`
- Paměťový problém auto-výběru vyřešen přes `CountingOutputStream`: serializovaná data se protáhnou každým kodérem, ale výstup se pouze počítá — žádná komprimovaná kopie se nedrží v paměti
- `serialize(obj, path, Compression)` je nyní plně streamovaný — objekt se zapisuje přímo přes kompresor na disk, žádný mezistupeň `byte[]`
- `openCompressor()` a `magicFor()` jsou exhaustivní switch výrazy přes enum — kompilátor upozorní na chybějící case při přidání nového kodeku

## Architektura paměti

| Cesta | Dříve | Nyní |
|---|---|---|
| `serialize(obj, path, true)` | raw + N × compressed `byte[]` v RAM | raw `byte[]` + malý streaming buffer |
| `serialize(obj, path, Compression)` | raw + compressed `byte[]` v RAM | žádný intermediate buffer |

## Test plan

- [x] `serializeAndDeserializeWithExplicitBzip2Codec` — round-trip BZip2
- [x] `bzip2CompressedFileIsSmallerForLargeData` — BZip2 < nekomprimované
- [x] `autoCompressionWritesCompressedMagicByte` — magic byte je 0x01, 0x02 nebo 0x03
- [x] `autoCompressionPicksSmallestCodec` — auto = min(GZIP, XZ, BZip2)
- [x] `allCodecsRoundTripComplexObject` — iteruje přes všechny hodnoty enumu (včetně BZIP2)
- [x] Všechny předchozí testy zelené (18 celkem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)